### PR TITLE
Injection -> Browser Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ There's not much to see right now.  The main part is activated with `Alt+Shift+Q
 ### High
 
 + Security [bug] {in-progress}
++ Anti-fingerprinting
 
 ### Medium
 
@@ -71,6 +72,7 @@ There's not much to see right now.  The main part is activated with `Alt+Shift+Q
 + Homepage [meta] {in-progress}
 + Customisation of highlight colour [feature]
 + Better mini-map styling [bug]
++ Move `src/cs/automatic` to `src/injections/automatic` [meta]
 
 ### Low
 

--- a/meta/changelog/index.html
+++ b/meta/changelog/index.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
+
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Kestrel | Changelog</title>
-        <link
-            rel="stylesheet"
-            type="text/css"
-            href="../../src/libs/index.css"
-        />
+        <link rel="stylesheet" type="text/css" href="../../src/libs/index.css" />
     </head>
 
     <body>
@@ -21,4 +18,5 @@
             <h1>Changelog</h1>
         </div>
     </body>
+
 </html>

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -6,17 +6,6 @@ browser.runtime.onInstalled.addListener(() => {
     );
 });
 
-/*
-    If Kestrel is active already, contains ids of tabs and their injection status
-
-    status[tab.id] {
-        injected: bool, // determines if needed scripts are injected, so they aren't injected again
-        active: bool // determines if kestrel is shown or not
-    }
-*/
-
-let status = {};
-
 // storage
 let settings;
 
@@ -31,48 +20,6 @@ let runtimes = {
     minimap: "document_idle",
     linksInSameTab: "document_end",
 };
-
-// Listens for commands
-browser.commands.onCommand.addListener(command => {
-    let actTab = getActiveTab();
-
-    actTab.then(data => {
-        updateSettings();
-
-        data = data.id;
-        if (!status[data]) {
-            status[data] = {
-                injected: false,
-                active: true,
-            };
-        }
-
-        if (command === "kestrel-activate" && !status[data].injected) {
-            // Open UI command
-            injectScripts();
-            status[data] = {
-                injected: true,
-                active: true,
-            };
-        } else if (
-            status[data].injected == true &&
-            status[data].active == true
-        ) {
-            removePalette(`../cs/ui.css`);
-            if (settings.theme !== "operating-system-default") {
-                removePalette(`../../libs/themes/${settings.theme}.css`);
-            }
-            status[data].active = false;
-        } else if (
-            status[data].injected == true &&
-            status[data].active == false
-        ) {
-            sendMessage({ kestrel: "show" });
-            injectStylesheet(`../cs/ui.css`);
-            status[data].active = true;
-        }
-    });
-});
 
 // updates all active userscripts from user settings (browser.storage api)
 function updateUserScripts() {
@@ -99,60 +46,6 @@ function updateUserScripts() {
         });
     });
 }
-
-// returns the currently active tab
-const getActiveTab = () => {
-    return browser.tabs
-        .query({
-            currentWindow: true,
-            active: true,
-        })
-        .then(tabs => {
-            return tabs[0];
-        })
-        .catch(err => console.error(err));
-};
-
-// critical js
-// injected in order of dependence
-// if one fails, kestrel cannot work
-
-// note: needs better error handling
-const injectScripts = () => {
-    injectStylesheet(`../cs/ui.css`);
-
-    browser.tabs
-        .executeScript({
-            // Injects main UI script
-            file: "../libs/taita.js",
-        })
-        .then(() => {
-            browser.tabs.executeScript({
-                file: "../libs/commands.js",
-            });
-        })
-        .then(() => {
-            browser.tabs.executeScript({
-                // Injects main UI script
-                file: "../cs/kestrel.js",
-            });
-        })
-        .then(() => {
-            browser.tabs.executeScript({
-                file: "../libs/utils.js",
-            });
-        })
-        .then(() => {
-            browser.tabs.executeScript({
-                // Injects main UI script
-                file: "../cs/ui.js",
-            });
-        })
-        .catch(injectScripts)
-        .finally(() => {
-            return;
-        });
-};
 
 const injectScript = (script) => {
     return browser.tabs.executeScript({ file: script })
@@ -205,36 +98,6 @@ function updateSettings() {
         })
         .catch(err => console.error(`Failed to load settings: ${err}`));
 }
-
-let contentPort;
-browser.runtime.onConnect.addListener(port => {
-    // Initial port connection to content script
-    if (port.sender.id !== browser.runtime.id) {
-        return;
-    }
-
-    contentPort = port;
-    sender = port.sender.id;
-    status[sender] = {
-        active: true,
-        injected: true,
-    };
-
-    if (contentPort) {
-        sendMessage({ kestrel: "connection-success" });
-    }
-    if (port.name === "kestrel") {
-        port.onMessage.addListener(msg => { });
-    }
-
-    contentPort.onDisconnect.addListener(msg => {
-        // tab is closed, removes tab status
-        status[msg.sender.id] = {
-            active: false,
-            injected: false,
-        };
-    });
-});
 
 // executes functions that require background script apis
 browser.runtime.onMessage.addListener((msg, sender, response) => {

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -154,6 +154,10 @@ const injectScripts = () => {
         });
 };
 
+const injectScript = (script) => {
+    return browser.tabs.executeScript({ file: script })
+}
+
 // controls injection of needed stylesheets
 // for now this is just cs/ui.css
 const injectStylesheet = sheet => {
@@ -264,6 +268,8 @@ browser.runtime.onMessage.addListener((msg, sender, response) => {
         registeredScripts = {};
     } else if (msg.settings == "get-manifest") {
         return new Promise(resolve => resolve(browser.runtime.getManifest()));
+    } else if (msg.inject) {
+        injectScript(`injections/${msg.inject}.js`);
     }
 });
 

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -210,7 +210,7 @@ browser.runtime.onConnect.addListener(port => {
     }
 
     contentPort = port;
-    sender = port.sender.tab.id;
+    sender = port.sender.id;
     status[sender] = {
         active: true,
         injected: true,
@@ -225,7 +225,7 @@ browser.runtime.onConnect.addListener(port => {
 
     contentPort.onDisconnect.addListener(msg => {
         // tab is closed, removes tab status
-        status[msg.sender.tab.id] = {
+        status[msg.sender.id] = {
             active: false,
             injected: false,
         };

--- a/src/cs/index.html
+++ b/src/cs/index.html
@@ -9,7 +9,6 @@
     </head>
 
     <body>
-        <script src="./kestrel.js"></script>
         <script src="./ui.js" type="module"></script>
     </body>
 

--- a/src/cs/index.html
+++ b/src/cs/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Kestrel - Seach Commands</title>
+        <link rel="stylesheet" type="text/css" href="./ui.css" />
+    </head>
+
+    <body>
+        <script src="./kestrel.js"></script>
+        <script src="./ui.js" type="module"></script>
+    </body>
+
+</html>

--- a/src/cs/kestrel.js
+++ b/src/cs/kestrel.js
@@ -1,87 +1,14 @@
 // Command Callbacks
 
+import { sendFnEvent } from './ui.js';
+
 // command callbacks, not listed in window object for organization and for preventing conflict
+// note: explicit returns of false denote that the function doesn't need access to the window (through injections)
 let cmdFunctions = {
-    // prevents all links from working
-    // note: there is no enable links function for a purpose; this command is to stop time wasting
-    disableLinks: function (ref) {
-        document
-            .querySelectorAll("a[href]")
-            .forEach(item => (item.style.pointerEvents = "none"));
-    },
-
-    // edit page using contentEditable
-    editPage: function (ref) {
-        document.querySelectorAll("body > *").forEach(item => {
-            if (item.className.includes("kestrel")) {
-                return;
-            } else {
-                if (
-                    item.contentEditable == "inherit" ||
-                    item.contentEditable == "false"
-                ) {
-                    item.contentEditable = "true";
-                    document.body
-                        .querySelectorAll("a[href]")
-                        .forEach(item => item.setAttribute("disabled", "true"));
-                } else if (item.contentEditable == "true") {
-                    item.contentEditable = "false";
-                    document.body
-                        .querySelectorAll("a[href]")
-                        .forEach(item => item.removeAttribute("disabled"));
-                }
-            }
-        });
-    },
-
-    // hides/shows images and video
-    mediaToggled: false,
-    toggleMedia: function (ref) {
-        if (!this.mediaToggled) {
-            this.mediaToggled = true;
-
-            if (ref.includes("media")) {
-                document
-                    .querySelectorAll("img,video")
-                    .forEach(item => (item.style.display = "none"));
-            } else if (ref.includes("video")) {
-                document
-                    .querySelectorAll("video")
-                    .forEach(item => (item.style.display = "none"));
-            } else if (ref.includes("image")) {
-                document
-                    .querySelectorAll("img")
-                    .forEach(item => (item.style.display = "none"));
-            }
-        } else if (this.mediaToggled) {
-            this.mediaToggled = false;
-
-            if (ref.includes("media")) {
-                document
-                    .querySelectorAll("img,video")
-                    .forEach(item => (item.style.display = ""));
-            } else if (ref.includes("video")) {
-                document
-                    .querySelectorAll("video")
-                    .forEach(item => (item.style.display = ""));
-            } else if (ref.includes("image")) {
-                document
-                    .querySelectorAll("img")
-                    .forEach(item => (item.style.display = ""));
-            }
-        }
-    },
-
     // opens Kestrel's settings/options page
     openSettings: function (ref) {
         sendFnEvent({ fn: "openSettings" });
-    },
-
-    // opens all links in the same tab
-    openInSameTab: function (ref) {
-        document.body
-            .querySelectorAll("a[href]")
-            .forEach(link => link.setAttribute("target", "_self"));
+        return false;
     },
 
     // refreshs all tabs
@@ -98,156 +25,19 @@ let cmdFunctions = {
                 args: { bypassCache: true },
             });
         }
+
+        return false;
     },
 
-    // scrolls to position based on reference
-    scrollTo: function (ref) {
-        if (ref.includes("top")) {
-            window.scrollTo(0, 0);
-        } else if (ref.includes("middle")) {
-            window.scrollTo(0, document.body.scrollHeight / 2);
-        } else if (ref.includes("bottom")) {
-            window.scrollTo(0, document.body.scrollHeight);
-        } else if (ref.includes("1/4")) {
-            window.scrollTo(0, document.body.scrollHeight * 0.25);
-        } else if (ref.includes("3/4")) {
-            window.scrollTo(0, document.body.scrollHeight * 0.75);
-        }
-    },
-
-    // disables/enables animations
-    toggleAnimations: function (ref) {
-        if (ref.includes("off")) {
-            Object.values(document.body.querySelectorAll("*")).forEach(item => {
-                if (
-                    item.className.includes("kestrel") ||
-                    item.getAnimations().length == 0
-                ) {
-                    return;
-                } else {
-                    item.getAnimations().forEach(animation =>
-                        animation.pause()
-                    );
-                }
-            });
-
-            cpal.updateCommand({
-                toggleAnimations: {
-                    name: "Toggle animations: on",
-                    callback: "toggleAnimations",
-                },
-            });
-        } else {
-            Object.values(document.body.querySelectorAll("*")).forEach(item => {
-                if (
-                    item.className.includes("kestrel") ||
-                    item.getAnimations().length == 0
-                ) {
-                    return;
-                }
-                item.getAnimations().forEach(animation => animation.play());
-            });
-
-            cpal.updateCommand({
-                toggleAnimations: {
-                    name: "Toggle animations: off",
-                    callback: "toggleAnimations",
-                },
-            });
-        }
-    },
-
-    // note: not completed
     // toggles a mini-map, similar to VSCode's
     // see https://css-tricks.com/using-the-little-known-css-element-function-to-create-a-minimap-navigator/
+    injectedMiniMap: false,
     toggleMiniMap: function (ref) {
-        if (
-            document.querySelector(
-                'div[data-kestrel-mini-map][id="kestrel-mini-map"]'
-            )
-        ) {
-            let container = document.querySelector(
-                'div[id="kestrel-mini-map-container"]'
-            );
-            Object.values(container.children).forEach(item =>
-                document.body.appendChild(item)
-            );
-
-            container.remove();
-
-            document
-                .querySelector(
-                    'div[data-kestrel-mini-map][id="kestrel-mini-map"]'
-                )
-                .remove();
-        } else {
+        if (this.injectedMiniMap == false) {
             sendFnEvent({ injectSheet: "minimap" });
-            let container = buildElement("div", "", {
-                id: "kestrel-mini-map-container",
-            });
-
-            Object.values(document.body.children).forEach(item => {
-                if (!item.className.includes("kestrel")) {
-                    container.appendChild(item);
-                }
-            });
-
-            document.body.appendChild(container);
-
-            let minimap = buildElement("div", "", {
-                data_kestrel_mini_map: true,
-                id: "kestrel-mini-map",
-                class: "kestrel-mini-map",
-            });
-
-            let selection = buildElement("input", "", {
-                type: "range",
-                id: "kestrel-mini-map-slider",
-                max: 100,
-                value: 0,
-            });
-
-            minimap.appendChild(selection);
-            minimap.style.display = "block";
-
-            document.body.appendChild(minimap);
-
-            const recalculate = () => {
-                let dimensions = `${
-                    (parseInt(getComputedStyle(selection).width) *
-                        parseInt(getComputedStyle(container).height)) /
-                    parseInt(getComputedStyle(container).width)
-                    }px`;
-
-                selection.style.width = dimensions;
-                minimap.style.height = dimensions;
-            };
-
-            recalculate();
-
-            window.addEventListener("resize", () => recalculate());
-            window.addEventListener(
-                "scroll",
-                () => {
-                    let percentage =
-                        ((document.documentElement.scrollTop ||
-                            document.body.scrollTop) /
-                            ((document.documentElement.scrollHeight ||
-                                document.body.scrollHeight) -
-                                document.documentElement.clientHeight)) *
-                        100;
-                    selection.value = percentage;
-                },
-                { passive: true }
-            );
-
-            selection.addEventListener("change", event => {
-                scrollTo(
-                    0,
-                    parseInt(getComputedStyle(container).height) *
-                    (event.target.value / 100)
-                );
-            });
+            this.injectedMiniMap = true;
         }
     },
 };
+
+export default cmdFunctions;

--- a/src/cs/kestrel.js
+++ b/src/cs/kestrel.js
@@ -217,7 +217,7 @@ let cmdFunctions = {
                     (parseInt(getComputedStyle(selection).width) *
                         parseInt(getComputedStyle(container).height)) /
                     parseInt(getComputedStyle(container).width)
-                }px`;
+                    }px`;
 
                 selection.style.width = dimensions;
                 minimap.style.height = dimensions;
@@ -245,7 +245,7 @@ let cmdFunctions = {
                 scrollTo(
                     0,
                     parseInt(getComputedStyle(container).height) *
-                        (event.target.value / 100)
+                    (event.target.value / 100)
                 );
             });
         }

--- a/src/cs/ui.css
+++ b/src/cs/ui.css
@@ -2,7 +2,7 @@
 	Global variables not changed by colour theme
 */
 
-.kestrel {
+body {
     --transition-primary: 100ms linear;
 }
 
@@ -10,7 +10,7 @@
 	Fallback if user hasn't set a colour theme preference
 */
 
-.kestrel {
+body {
     --kestrel-primary: #fafafa;
     --kestrel-secondary: #404040;
     --kestrel-tertiary: #f1f2f3;
@@ -18,7 +18,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .kestrel {
+    body {
         --kestrel-primary: #212121;
         --kestrel-secondary: #fafafa;
         --kestrel-tertiary: #404040;
@@ -26,13 +26,11 @@
     }
 }
 
-/*
-	Dims background
-*/
-
-body > *:not(.kestrel) {
-    opacity: 0.2;
-    pointer-events: none;
+body {
+    width: 600px;
+    padding: 0;
+    margin: 0;
+    background: var(--kestrel-primary);
 }
 
 /*
@@ -46,18 +44,10 @@ body > *:not(.kestrel) {
 
     width: 100%;
     max-width: 800px;
-    min-height: 400px;
-    max-height: 1000px;
 
     margin: 0 auto;
     animation: none;
     transition: none;
-
-    position: fixed;
-    top: 10%;
-    left: 50%;
-    transform: translate(-50%, 0%);
-    z-index: 99999;
 }
 
 .kestrel:focus {

--- a/src/cs/ui.js
+++ b/src/cs/ui.js
@@ -101,7 +101,8 @@ const updateCommands = () => {
         });
 
         commandItem.addEventListener("click", () => {
-            cpal.execute(commandItem.innerText, cmdFunctions);
+            sendFnEvent({ inject: cpal._commandContains(commandItem.innerText) });
+            console.log(cpal._commandContains(commandItem.innerText))
             updateCommands();
         });
 
@@ -131,7 +132,8 @@ function listen(event) {
     if (event.keyCode == 13 && commandList) {
         Object.values(commandList.children).forEach(child => {
             if (child.classList.contains("kestrel-command-item-focused")) {
-                cpal.execute(child.innerText, cmdFunctions);
+                sendFnEvent({ inject: cpal._commandContains(child.innerText) });
+                console.log(cpal._commandContains(child.innerText))
             }
         });
         commandInp.value = "";

--- a/src/cs/ui.js
+++ b/src/cs/ui.js
@@ -24,6 +24,7 @@ Structure
 
 import buildElement from '../libs/utils.js';
 import { cpal, commands } from '../libs/commands.js';
+import cmdFunctions from './kestrel.js';
 
 let kestrel;
 let commandInp;
@@ -101,8 +102,8 @@ const updateCommands = () => {
         });
 
         commandItem.addEventListener("click", () => {
-            sendFnEvent({ inject: cpal._commandContains(commandItem.innerText) });
-            console.log(cpal._commandContains(commandItem.innerText))
+            let c = cpal.execute(commandItem.innerText, cmdFunctions);
+            if (c != false) sendFnEvent({ inject: cpal._commandContains(commandItem.innerText) });
             updateCommands();
         });
 
@@ -132,8 +133,8 @@ function listen(event) {
     if (event.keyCode == 13 && commandList) {
         Object.values(commandList.children).forEach(child => {
             if (child.classList.contains("kestrel-command-item-focused")) {
-                sendFnEvent({ inject: cpal._commandContains(child.innerText) });
-                console.log(cpal._commandContains(child.innerText))
+                let c = cpal.execute(child.innerText, cmdFunctions);
+                if (c != false) sendFnEvent({ inject: cpal._commandContains(child.innerText) });
             }
         });
         commandInp.value = "";
@@ -237,3 +238,5 @@ function clearCommands() {
 }
 
 buildUI();
+
+export { sendFnEvent };

--- a/src/cs/ui.js
+++ b/src/cs/ui.js
@@ -22,18 +22,18 @@ Structure
 </body>
 */
 
+import buildElement from '../libs/utils.js';
+import { cpal, commands } from '../libs/commands.js';
+
 let kestrel;
 let commandInp;
 let commandIndex = 0;
 
-// taita instance
-const cpal = new Taita(commands, {
-    sort: "alphabetical",
-});
-
 let commandsChanged = cpal.matchedCommands.changed();
 
 let port;
+
+let settings;
 
 // generates command palette and logic
 function buildUI() {
@@ -102,6 +102,7 @@ const updateCommands = () => {
 
         commandItem.addEventListener("click", () => {
             cpal.execute(commandItem.innerText, cmdFunctions);
+            updateCommands();
         });
 
         commandItem.addEventListener("mouseover", () => {

--- a/src/injections/disableLinks.js
+++ b/src/injections/disableLinks.js
@@ -1,0 +1,3 @@
+(function () {
+    document.querySelectorAll("a[href]").forEach(item => (item.style.pointerEvents = "none"));
+}());

--- a/src/injections/disableLinks.js
+++ b/src/injections/disableLinks.js
@@ -1,3 +1,5 @@
+// prevents all links from working
+// note: there is no enable links function for a purpose; this command is to stop time wasting
 (function () {
     document.querySelectorAll("a[href]").forEach(item => (item.style.pointerEvents = "none"));
 }());

--- a/src/injections/openInSameTab.js
+++ b/src/injections/openInSameTab.js
@@ -1,0 +1,4 @@
+// opens all links in the same tab
+(function () {
+    document.body.querySelectorAll("a[href]").forEach(link => link.setAttribute("target", "_self"));
+}());

--- a/src/injections/scrollToBottom.js
+++ b/src/injections/scrollToBottom.js
@@ -1,0 +1,4 @@
+// scrolls to bottom of page
+(function () {
+    window.scrollTo(0, document.body.scrollHeight);
+}());

--- a/src/injections/scrollToMiddle.js
+++ b/src/injections/scrollToMiddle.js
@@ -1,0 +1,4 @@
+// scrolls to middle of page
+(function () {
+    window.scrollTo(0, document.body.scrollHeight / 2);
+}());

--- a/src/injections/scrollToOneFourth.js
+++ b/src/injections/scrollToOneFourth.js
@@ -1,0 +1,4 @@
+// scrolls to one-fourth the page height
+(function () {
+    window.scrollTo(0, document.body.scrollHeight * 0.25);
+}());

--- a/src/injections/scrollToThreeFourths.js
+++ b/src/injections/scrollToThreeFourths.js
@@ -1,0 +1,4 @@
+// scrolls to three-fourths the page height
+(function () {
+    window.scrollTo(0, document.body.scrollHeight * 0.75);
+}());

--- a/src/injections/scrollToTop.js
+++ b/src/injections/scrollToTop.js
@@ -1,0 +1,4 @@
+// scrolls to top
+(function () {
+    window.scrollTo(0, 0);
+}());

--- a/src/injections/toggleAnimations.js
+++ b/src/injections/toggleAnimations.js
@@ -1,0 +1,18 @@
+// disables/enables animations
+(function () {
+    let ref = Object.values(document.body.querySelectorAll('*')).some(item => item.getAnimations().some(animation => animation.playState == "paused"));
+    if (ref == false) {
+        Object.values(document.body.querySelectorAll("*")).forEach(item => {
+            if (item.getAnimations().length == 0) return;
+
+            item.getAnimations().forEach(animation =>
+                animation.pause()
+            );
+        });
+    } else if (ref == true) {
+        Object.values(document.body.querySelectorAll("*")).forEach(item => {
+            if (item.getAnimations().length == 0) return
+            item.getAnimations().forEach(animation => animation.play());
+        });
+    }
+}());

--- a/src/injections/toggleEditPage.js
+++ b/src/injections/toggleEditPage.js
@@ -1,0 +1,14 @@
+(function () {
+    let b = document.body;
+    if (b.contentEditable == "inherit" || b.contentEditable == "false") {
+        b.contentEditable = "true";
+        document.body
+            .querySelectorAll("a[href]")
+            .forEach(b => b.setAttribute("disabled", "true"));
+    } else if (b.contentEditable == "true") {
+        b.contentEditable = "false";
+        document.body
+            .querySelectorAll("a[href]")
+            .forEach(b => b.removeAttribute("disabled"));
+    }
+}());

--- a/src/injections/toggleEditPage.js
+++ b/src/injections/toggleEditPage.js
@@ -1,3 +1,4 @@
+// edit page using contentEditable
 (function () {
     let b = document.body;
     if (b.contentEditable == "inherit" || b.contentEditable == "false") {

--- a/src/injections/toggleImages.js
+++ b/src/injections/toggleImages.js
@@ -1,0 +1,9 @@
+// hides/shows images
+(function () {
+    let toggled = Object.values(document.querySelectorAll('img')).some((element) => element.style.display == 'none');
+    if (toggled == false) {
+        document.querySelectorAll("img").forEach(item => (item.style.display = "none"));
+    } else if (toggled == true) {
+        document.querySelectorAll("img").forEach(item => (item.style.display = ""));
+    }
+}());

--- a/src/injections/toggleMedia.js
+++ b/src/injections/toggleMedia.js
@@ -1,0 +1,9 @@
+// hides/shows images and video
+(function () {
+    let toggled = Object.values(document.querySelectorAll('img,video')).some((element) => element.style.display == 'none');
+    if (toggled == false) {
+        document.querySelectorAll("img,video").forEach(item => (item.style.display = "none"));
+    } else if (toggled == true) {
+        document.querySelectorAll("img,video").forEach(item => (item.style.display = ""));
+    }
+}());

--- a/src/injections/toggleMiniMap.js
+++ b/src/injections/toggleMiniMap.js
@@ -1,0 +1,105 @@
+// toggles a mini-map, similar to VSCode's
+// see https://css-tricks.com/using-the-little-known-css-element-function-to-create-a-minimap-navigator/
+(function () {
+    const buildElement = (type, text, attributes) => {
+        let element = document.createElement(type);
+        element.innerText = text || "";
+        if (attributes) {
+            Object.keys(attributes).forEach(item => {
+                if (item.includes("data_")) {
+                    element.setAttribute(
+                        item.replace(new RegExp("_", "g"), "-"),
+                        attributes[item]
+                    );
+                } else {
+                    element[item] = attributes[item];
+                }
+            });
+        }
+        return element;
+    };
+
+    if (document.querySelector('div[data-kestrel-mini-map][id="kestrel-mini-map"]')) {
+        let container = document.querySelector(
+            'div[id="kestrel-mini-map-container"]'
+        );
+        Object.values(container.children).forEach(item =>
+            document.body.appendChild(item)
+        );
+
+        container.remove();
+
+        document
+            .querySelector(
+                'div[data-kestrel-mini-map][id="kestrel-mini-map"]'
+            )
+            .remove();
+    } else {
+        let container = buildElement("div", "", {
+            id: "kestrel-mini-map-container",
+        });
+
+        Object.values(document.body.children).forEach(item => {
+            if (!item.className.includes("kestrel")) {
+                container.appendChild(item);
+            }
+        });
+
+        document.body.appendChild(container);
+
+        let minimap = buildElement("div", "", {
+            data_kestrel_mini_map: true,
+            id: "kestrel-mini-map",
+            class: "kestrel-mini-map",
+        });
+
+        let selection = buildElement("input", "", {
+            type: "range",
+            id: "kestrel-mini-map-slider",
+            max: 100,
+            value: 0,
+        });
+
+        minimap.appendChild(selection);
+        minimap.style.display = "block";
+
+        document.body.appendChild(minimap);
+
+        const recalculate = () => {
+            let dimensions = `${
+                (parseInt(getComputedStyle(selection).width) *
+                    parseInt(getComputedStyle(container).height)) /
+                parseInt(getComputedStyle(container).width)
+                }px`;
+
+            selection.style.width = dimensions;
+            minimap.style.height = dimensions;
+        };
+
+        recalculate();
+
+        window.addEventListener("resize", () => recalculate());
+        window.addEventListener(
+            "scroll",
+            () => {
+                let percentage =
+                    ((document.documentElement.scrollTop ||
+                        document.body.scrollTop) /
+                        ((document.documentElement.scrollHeight ||
+                            document.body.scrollHeight) -
+                            document.documentElement.clientHeight)) *
+                    100;
+                selection.value = percentage;
+            },
+            { passive: true }
+        );
+
+        selection.addEventListener("change", event => {
+            scrollTo(
+                0,
+                parseInt(getComputedStyle(container).height) *
+                (event.target.value / 100)
+            );
+        });
+    }
+}());

--- a/src/injections/toggleVideo.js
+++ b/src/injections/toggleVideo.js
@@ -1,0 +1,9 @@
+// hides/shows video
+(function () {
+    let toggled = Object.values(document.querySelectorAll('video')).some((element) => element.style.display == 'none');
+    if (toggled == false) {
+        document.querySelectorAll("video").forEach(item => (item.style.display = "none"));
+    } else if (toggled == true) {
+        document.querySelectorAll("video").forEach(item => (item.style.display = ""));
+    }
+}());

--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -36,10 +36,12 @@ const commands = {
     scrollToOneFourth: {
         name: "Scroll to 1/4 of the page",
         callback: "scrollToOneFourth",
+        on: false,
     },
     scrollToThreeFourths: {
         name: "Scroll to 3/4 of the page",
         callback: "scrollToThreeFourths",
+        on: false,
     },
     toggleAnimations: {
         name: "Toggle animations: off",

--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -21,15 +21,25 @@ const commands = {
         callback: "refreshTabs",
         aliases: ["Refresh all tabs: hard"],
     },
-    scrollTo: {
+    scrollToTop: {
         name: "Scroll to top of the page",
-        callback: "scrollTo",
-        aliases: [
-            "Scroll to 1/4 of the page",
-            "Scroll to middle of the page",
-            "Scroll to 3/4 of the page",
-            "Scroll to bottom of the page",
-        ],
+        callback: "scrollToTop",
+    },
+    scrollToBottom: {
+        name: "Scroll to the bottom of the page",
+        callback: "scrollToBottom",
+    },
+    scrollToMiddle: {
+        name: "Scroll to the middle of the page",
+        callback: "scrollToMiddle",
+    },
+    scrollToOneFourth: {
+        name: "Scroll to 1/4 of the page",
+        callback: "scrollToOneFourth",
+    },
+    scrollToThreeFourths: {
+        name: "Scroll to 3/4 of the page",
+        callback: "scrollToThreeFourths",
     },
     toggleAnimations: {
         name: "Toggle animations: off",
@@ -43,7 +53,14 @@ const commands = {
     toggleMedia: {
         name: "Toggle media",
         callback: "toggleMedia",
-        aliases: ["Toggle images", "Toggle video"],
+    },
+    toggleVideo: {
+        name: "Toggle video",
+        callback: "toggleVideo",
+    },
+    toggleImages: {
+        name: "Toggle images",
+        callback: "toggleImages",
     },
     toggleMiniMap: {
         name: "Toggle minimap",

--- a/src/libs/commands.js
+++ b/src/libs/commands.js
@@ -1,3 +1,5 @@
+import Taita from './taita.js';
+
 // Command palette variables
 const commands = {
     disableLinks: {
@@ -68,3 +70,10 @@ const automaticSettings = {
         colour: `#16c581`,
     },
 };
+
+// taita instance
+const cpal = new Taita(commands, {
+    sort: "alphabetical",
+});
+
+export { commands, cpal, automaticCommandsList, automaticSettings };

--- a/src/libs/taita.js
+++ b/src/libs/taita.js
@@ -403,7 +403,10 @@ class Taita {
         if (!obj) {
             obj = window;
         }
-        obj[callback](command);
+
+        if (!obj[callback]) return true;
+
+        return obj[callback](command);
     }
 
     _generateError(error, msg) {

--- a/src/libs/taita.js
+++ b/src/libs/taita.js
@@ -410,8 +410,10 @@ class Taita {
         // Developer mode erorr reporting
         console.error(
             `Taita error${this.options.items.dev ? `: ${msg}` : "."}${
-                error ? `  Error: ${error}` : ""
+            error ? `  Error: ${error}` : ""
             }`
         );
     }
 }
+
+export default Taita;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,13 +32,20 @@
         "api_script": "background/scriptApi.js"
     },
     "commands": {
-        "kestrel-activate": {
+        "_execute_browser_action": {
             "suggested_key": {
                 "default": "Alt+Shift+Q",
                 "linux": "Ctrl+Shift+Q"
             },
             "description": "Open Kestrel command interface"
         }
+    },
+    "browser_action": {
+        "default_icon": {
+            "19": "icons/icon.png"
+        },
+        "default_title": "Kestrel - Search Commands",
+        "default_popup": "cs/index.html"
     },
     "options_ui": {
         "page": "pages/settings/index.html",

--- a/src/pages/settings/build.js
+++ b/src/pages/settings/build.js
@@ -1,3 +1,4 @@
+import { automaticCommandsList } from '../../libs/commands.js';
 import buildElement from '../../libs/utils.js';
 import { settings, toggleTheme, automaticDescriptions } from './settings.js';
 import callbacks from './callbacks.js'

--- a/src/pages/settings/index.html
+++ b/src/pages/settings/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -23,7 +24,7 @@
             allows Kestrel to save your settings, and for Kestrel to function.
         </noscript>
         <script src="../changelog.js" defer type="module"></script>
-        <script src="../../libs/commands.js"></script>
         <script src="./update.js" type="module"></script>
     </body>
+
 </html>

--- a/src/pages/settings/update.js
+++ b/src/pages/settings/update.js
@@ -1,3 +1,4 @@
+import { automaticCommandsList, automaticSettings } from '../../libs/commands.js';
 import buildElement from '../../libs/utils.js';
 import build from './build.js';
 import { toggleTheme } from './settings.js';

--- a/src/pages/settings/update.js
+++ b/src/pages/settings/update.js
@@ -1,4 +1,4 @@
-import { automaticCommandsList, automaticSettings } from '../../libs/commands.js';
+import { automaticCommandsList, automaticSettings, commands } from '../../libs/commands.js';
 import buildElement from '../../libs/utils.js';
 import build from './build.js';
 import { toggleTheme } from './settings.js';


### PR DESCRIPTION
This pull request completely switches Kestrel from injection-based to [browser action](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_actions) based.  This fixes any injection styling issues.  It also forces commands that require `window` access to be injected in one-off files.

Overall, it's an improvement from the injection-based approach.  It also seems significantly faster, as Kestrel is no longer injecting a lot of scripts directly into the page.